### PR TITLE
Adjust track and album art responsive styling

### DIFF
--- a/sources/PugetSound/PugetSound/Views/Internal/Room.cshtml
+++ b/sources/PugetSound/PugetSound/Views/Internal/Room.cshtml
@@ -16,11 +16,11 @@
     </div>
     <hr />
     <div class="row align-items-center">
-        <div class="col-sm-auto">
-            <img width="250" height="250" id="currentSongArt" />
-            <progress id="currentProgress" value="0" max="100"></progress>
+        <div class="col-lg-4 col-md-5 col-sm-6">
+            <img class="puget-album-art" width="250" id="currentSongArt" />
+            <progress class="puget-track-progress" id="currentProgress" value="0" max="100"></progress>
         </div>
-        <div class="col-sm-auto">
+        <div class="col-lg-8 col-md-7 col-sm-6">
             <h5>Now playing:</h5>
             <div class="mt-3 mb-3 pl-3 border-left border-success">
                 <p id="currentSongTitle" class="font-weight-bold">-</p>

--- a/sources/PugetSound/PugetSound/wwwroot/css/site.css
+++ b/sources/PugetSound/PugetSound/wwwroot/css/site.css
@@ -419,6 +419,16 @@ a.whitelink:hover {
     background: rgba(255, 50, 50, 0.5);
 }
 
+.puget-album-art {
+    max-width: 100%;
+    max-height: 250px;
+    height: 100%;
+}
+
+.puget-track-progress {
+    max-width: 100%;
+}
+
 @keyframes flashing-yellow-border {
     0% {
         border: 2px solid yellow;


### PR DESCRIPTION
Fixes a couple of bugs with long track titles or artist information and responsive styles.

- Album image will be correct aspect ratio for image (some images are Album covers and not perfect squares)
- Track information will always be to the right of the album image until very small screens where it will go underneath.
- Album image no longer will escape the bounds of its container.